### PR TITLE
Tapestry 5.3.0

### DIFF
--- a/tapestryapp/pom.xml
+++ b/tapestryapp/pom.xml
@@ -111,6 +111,6 @@ of a Tapestry Maven plugin is not required.   -->
     </pluginRepositories>
 
     <properties>
-        <tapestry-release-version>5.2.5</tapestry-release-version>
+        <tapestry-release-version>5.3.0</tapestry-release-version>
     </properties>
 </project>

--- a/tapestryapp/pom.xml
+++ b/tapestryapp/pom.xml
@@ -111,6 +111,6 @@ of a Tapestry Maven plugin is not required.   -->
     </pluginRepositories>
 
     <properties>
-        <tapestry-release-version>5.3.0</tapestry-release-version>
+        <tapestry-release-version>5.3</tapestry-release-version>
     </properties>
 </project>

--- a/tapestryapp/src/main/java/tapestryapp/services/AppModule.java
+++ b/tapestryapp/src/main/java/tapestryapp/services/AppModule.java
@@ -19,7 +19,6 @@ public class AppModule
         configuration.add(SymbolConstants.SUPPORTED_LOCALES, "en");
         configuration.add(SymbolConstants.APPLICATION_VERSION, "1.0-SNAPSHOT");
         configuration.add(SymbolConstants.DEFAULT_STYLESHEET, "context:default.css" );
-        configuration.add(SymbolConstants.DEFAULT_JAVASCRIPT, "" );
         configuration.add(SymbolConstants.BLACKBIRD_ENABLED, "false");
         configuration.add(SymbolConstants.COMBINE_SCRIPTS, "false" );
         configuration.add(SymbolConstants.GZIP_COMPRESSION_ENABLED, "false");


### PR DESCRIPTION
jtdev, I'd greatly appreciate if you could still find the time to re-run the benchmarks:
Update to Tapestry 5.3.0 alpha release, remove DEFAULT_JAVASCRIPT symbol contribution as obsolete
